### PR TITLE
Removed news and events page from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <div class="topnav">
             <div class="nav-menu">
                 <a href="index.html">HOME</a>
-                <a href="news_and_events.html">NEWS&EVENTS</a>
+                <!-- <a href="news_and_events.html">NEWS&EVENTS</a> -->
                 <a href="resources.html">RESOURCES</a>
 <!--                <a href="donate.html">DONATE</a>-->
             </div>

--- a/news_and_events.html
+++ b/news_and_events.html
@@ -14,7 +14,7 @@
       <div class="topnav">
         <div class="nav-menu">
           <a href="index.html">HOME</a>
-          <a href="news_and_events.html">NEWS&EVENTS</a>
+          <!-- <a href="news_and_events.html">NEWS&EVENTS</a> -->
           <a href="resources.html">RESOURCES</a>
 <!--          <a href="#">DONATE</a>-->
         </div>

--- a/resources.html
+++ b/resources.html
@@ -12,9 +12,9 @@
             <div class="topnav">
                 <div class="nav-menu">
                     <a href="index.html">HOME</a>
-                    <a href="news_and_events.html">NEWS&EVENTS</a>
+                    <!-- <a href="news_and_events.html">NEWS&EVENTS</a> -->
                     <a href="#">RESOURCES</a>
-                 <!--   <a href="#">DONATE</a>-->
+                    <!--   <a href="#">DONATE</a>-->
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
Fixes issue #6 

## Changes
Removed the News & Events page from the headers on the main events page and resources page.